### PR TITLE
vote event binding is now delegated from document, fixes weird bug

### DIFF
--- a/app/assets/javascripts/votes.js
+++ b/app/assets/javascripts/votes.js
@@ -3,8 +3,8 @@ $(document).ready(function(){
 });
 
 function bindVotes(){
-  $('.upvote').on('click', function(event){ vote(event, true) });
-  $('.downvote').on('click', function(event){ vote(event, false) });
+  $(document).on('click', '.upvote', function(event){ vote(event, true) });
+  $(document).on('click', '.downvote', function(event){ vote(event, false) });
 }
 
 function vote(event, vote){


### PR DESCRIPTION
Voting wasn't working when navigating to a film show page from the main page, but worked on reload or on back from the 404. Fixed by binding the actions to the document and delegating the event to the vote links instead of binding directly.
